### PR TITLE
feat : 검색 기능 구현

### DIFF
--- a/src/componenet/SoccerTeamList.js
+++ b/src/componenet/SoccerTeamList.js
@@ -6,7 +6,8 @@ import '../css/CommonStyle.css';
 
 const SoccerTeamList = () => {
   const [teams, setTeams] = useState([]);
-  const [searchType, setSearchType] = useState('title');
+  const [filteredTeams, setFilteredTeams] = useState([]);
+  const [searchType, setSearchType] = useState('teamName');
   const [searchTerm, setSearchTerm] = useState('');
 
   useEffect(() => {
@@ -15,33 +16,38 @@ const SoccerTeamList = () => {
         const token = localStorage.getItem("token");
         const response = await axios.get('http://localhost:8080/api/soccerTeam', { headers: { Authorization: token } });
         setTeams(response.data.data);
+        setFilteredTeams(response.data.data); // 초기 로드 시 전체 데이터를 filteredTeams에 설정
       } catch (error) {
         console.error('Error fetching teams:', error);
         setTeams([]);
+        setFilteredTeams([]); // 오류 발생 시 filteredTeams도 빈 배열로 설정
       }
     };
   
     fetchTeams();
   }, []);
 
-  console.log('Current teams state:', teams);
+  useEffect(() => {
+    handleSearch();
+  }, [searchType, searchTerm]);
 
-    const handleSearch = () => {
-    const filteredTeams = teams.filter(team => {
+  const handleSearch = () => {
+    const filtered = teams.filter(team => {
       if (searchType === 'teamName') {
         return team.name.toLowerCase().includes(searchTerm.toLowerCase());
       } else if (searchType === 'region') {
         return team.region.toLowerCase().includes(searchTerm.toLowerCase());
       }
-      return true;
+      return false;
     });
-    setTeams(filteredTeams);
+    console.log('Search term:', searchTerm); // 검색어를 콘솔에 출력
+    console.log('Filtered teams:', filtered); // 필터링된 결과를 콘솔에 출력
+    setFilteredTeams(filtered); // 필터링된 결과를 filteredTeams에 설정
   };
 
   return (
     <div className="list-container">
       <div className="header-container">
-
         <div className="search-actions">
           <select
             value={searchType}
@@ -58,7 +64,6 @@ const SoccerTeamList = () => {
             onChange={(e) => setSearchTerm(e.target.value)}
             className="search-input"
           />
-          <button onClick={handleSearch} className="search-button">검색</button>
         </div>
 
         <h2 className="title">팀 게시판</h2>
@@ -79,8 +84,8 @@ const SoccerTeamList = () => {
             </tr>
           </thead>
           <tbody>
-            {Array.isArray(teams) && teams.length > 0 ? (
-              teams.map(team => (
+            {Array.isArray(filteredTeams) && filteredTeams.length > 0 ? (
+              filteredTeams.map(team => (
                 <tr key={team.id}>
                   <td>{team.id}</td>
                   <td>

--- a/src/componenet/SoccerTeamList.js
+++ b/src/componenet/SoccerTeamList.js
@@ -19,8 +19,8 @@ const SoccerTeamList = () => {
         setFilteredTeams(response.data.data); // 초기 로드 시 전체 데이터를 filteredTeams에 설정
       } catch (error) {
         console.error('Error fetching teams:', error);
-        setTeams([]);
-        setFilteredTeams([]); // 오류 발생 시 filteredTeams도 빈 배열로 설정
+        setTeams([]); // 오류 발생 시 빈 배열로 설정
+        setFilteredTeams([]); // 오류 발생 시 빈 배열로 설정
       }
     };
   
@@ -40,8 +40,6 @@ const SoccerTeamList = () => {
       }
       return false;
     });
-    console.log('Search term:', searchTerm); // 검색어를 콘솔에 출력
-    console.log('Filtered teams:', filtered); // 필터링된 결과를 콘솔에 출력
     setFilteredTeams(filtered); // 필터링된 결과를 filteredTeams에 설정
   };
 


### PR DESCRIPTION
검색 버튼의 필요성이 사라져 다시 삭제했습니다.

1. 상태 관리 (useState)
- teams: API로부터 가져온 모든 팀 데이터를 저장합니다.
- filteredTeams: 검색 결과로 필터링된 팀 목록을 저장합니다.
- searchType: 사용자가 선택한 검색 유형(팀 이름 또는 운영 지역)을 저장합니다.
- searchTerm: 사용자가 입력한 검색어를 저장합니다.

2. 데이터 가져오기 (useEffect)
- 컴포넌트가 처음 렌더링될 때 팀 데이터를 서버에서 가져옵니다.
- fetchTeams 함수는 성공적으로 데이터를 가져오면 teams와 filteredTeams 상태를 업데이트합니다. 오류가 발생하면 두 상태를 빈 배열로 설정합니다.
- 초기에는 filteredTeams를 teams와 동일하게 설정하여 모든 팀을 표시합니다.

3. 검색 기능 (useEffect와 handleSearch)
- 자동 검색 (useEffect):
    - 검색 유형(searchType)이나 검색어(searchTerm)가 변경될 때마다 useEffect 훅이 트리거되어 handleSearch 함수가 호출됩니다. 이로 인해 사용자가 검색 조건을 변경할 때마다 실시간으로 검색 결과가 업데이트됩니다.
- 검색 로직 (handleSearch):
    - handleSearch 함수는 teams 배열에서 사용자가 입력한 검색 조건에 따라 팀을 필터링합니다.
    - searchType에 따라 팀 이름(team.name) 또는 운영 지역(team.region)이 검색어(searchTerm)를 포함하는지 확인합니다.
    - 필터링 된 결과는 filteredTeams 상태에 저장되어 렌더링됩니다.
  
4. UI 렌더링
- 검색 조건이 반영된 filteredTeams를 기반으로 테이블을 렌더링합니다.
- 사용자가 searchType 드롭다운에서 팀 이름이나 운영 지역을 선택하고, 검색어를 입력하면, 이 입력에 따라 테이블에 표시되는 팀 목록이 실시간으로 변경됩니다. 입력하는 동안에도 handleSearch가 실행되어 filteredTeams가 업데이트되므로, 검색 결과가 즉시 표시됩니다.

---------------------------------------------------------

아래의 콘솔 로그를 사용해서 검색어와 필터링 결과를 확인했습니다.
console.log('Search term:', searchTerm); // 검색어를 콘솔에 출력
console.log('Filtered teams:', filtered); // 필터링된 결과를 콘솔에 출력

초기 상태
<img width="1607" alt="image" src="https://github.com/user-attachments/assets/05fc18ee-7be7-4dc0-afed-ff1ef94abcec">

팀 이름 'fc'로 검색
<img width="1607" alt="image" src="https://github.com/user-attachments/assets/fa72c0b4-1d33-48f9-8b59-010c20558539">

검색어를 지우면 처음 상태로 초기화
<img width="1607" alt="image" src="https://github.com/user-attachments/assets/21e33e30-d3e4-4fd4-8ccb-70da17ea7b68">

운영 지역으로 변경하고 '서울' 검색
<img width="1607" alt="image" src="https://github.com/user-attachments/assets/5cff55fc-7f99-40d2-8e9c-f8c79b5db33c">

검색어 '서울'인 상태에서 팀 이름으로 변경
<img width="1607" alt="image" src="https://github.com/user-attachments/assets/4fae1822-f0aa-4df7-becb-035a288d7a0a">
