### PR TITLE
feat: 선수 list 불러오기

### DIFF
--- a/src/componenet/SoccerTeamDetail.js
+++ b/src/componenet/SoccerTeamDetail.js
@@ -27,9 +27,26 @@ function SoccerTeamDetail() {
       console.error('Error fetching soccer team details:', response.error);
     }
   }
+
+  const getPlayerList = async () => {
+    const token = localStorage.getItem("token");
+    try {
+      const response = await axios.get(`http://localhost:8080/api/enroll/team/${teamIdx}`, {
+        headers: {
+          Authorization: token
+        }
+      });
+      if (response.data && response.status === 200) {
+        setPlayerList(response.data.data);
+      }
+    } catch (error) {
+      console.error('Error fetching player list:', error);
+    }
+  }
   
   useEffect(() => {
     getData();
+    getPlayerList();
   }, [teamIdx]);
 
   if (!soccerTeam) return <div>Loading...</div>;
@@ -61,7 +78,7 @@ function SoccerTeamDetail() {
               <td>{soccerTeam.name}</td>
               <th scope="row">작성자</th>
               <td>{soccerTeam.player.name}</td>
-              <th scope="row">연락처</th>
+              <th scope="row">전화번호</th>
               <td colSpan="3">{soccerTeam.phoneNumber}</td>
             </tr>
             <tr>
@@ -126,7 +143,7 @@ function SoccerTeamDetail() {
               <th>선출 여부</th>
               <th>선수 이름</th>
               <th>제목</th>
-              <th>지역</th>
+              <th>전화번호</th>
               <th>등록일</th>
               <th>수정일</th>
             </tr>
@@ -136,9 +153,9 @@ function SoccerTeamDetail() {
               playerList.map(player => (
                 <tr key={player.id}>
                   <td>{player.athlete ? 'O' : 'X'}</td>
-                  <td><a href={`/playerDetail/${player.id}`}>{player.name}</a></td>
+                  <td><a href={`/playerDetail/${player.id}`}>{player.playerName}</a></td>
                   <td><a href={`/playerDetail/${player.id}`}>{player.title}</a></td>
-                  <td>{player.region}</td>
+                  <td>{player.phoneNumber}</td>
                   <td>{player.createdAt}</td>
                   <td>{player.updatedAt}</td>
                 </tr>


### PR DESCRIPTION
getPlayerList 함수로 특정 팀에 입단 신청된 선수들의 목록을 가져옵니다.
axios.get을 사용하여 서버로부터 선수 목록을 가져오는 요청을 보내고 요청이 성공하면, 반환된 선수 목록 데이터를 setPlayerList를 사용해 상태에 저장합니다.

useEffect 훅에 추가하여 teamIdx가 변경될 때마다 훅이 재실행되어 새롭게 선택된 팀의 데이터와 선수 목록을 가져옵니다.

- 글 번호 1의 팀 게시판 선수 목록
<img width="1227" alt="image" src="https://github.com/user-attachments/assets/3f52d6c5-5062-47fa-9002-a38e82dbe21c">

- 글 번호 3의 팀 게시판 선수 목록
<img width="1227" alt="image" src="https://github.com/user-attachments/assets/559d6a20-60ef-42a5-aa93-54a61e6e869f">
