### PR TITLE
feat: 입단 신청 update

### DIFF
--- a/src/soccerTeam/PlayerDetail.js
+++ b/src/soccerTeam/PlayerDetail.js
@@ -93,7 +93,7 @@ function PlayerDetail() {
         </table>
       </form>
       <button className="btnPD" onClick={() => navigate(`/soccerTeam/${teamId}`)}>목록으로</button>
-      <button className="btnPD" onClick={() => navigate(`/playerModify/${playerIdx}`, {state: {enroll}})}>수정하기</button>
+      <button className="btnPD" onClick={() => {navigate(`/playerModify/${playerIdx}`, { state: { enroll, teamId } });}}>수정하기</button>
       <button className="btnPD" onClick={handleDelete}>삭제하기</button>
     </div>
   );

--- a/src/soccerTeam/PlayerModify.js
+++ b/src/soccerTeam/PlayerModify.js
@@ -1,6 +1,140 @@
+// import React, { useState, useEffect } from 'react';
+// import axios from 'axios';
+// import { useParams, useNavigate } from 'react-router-dom';
+// import '../css/PlayerWrite.css';
+
+// function PlayerModify() {
+//   const { playerIdx } = useParams();
+//   const navigate = useNavigate();
+//   const [formData, setFormData] = useState({
+//     title: '',
+//     playerName: '',
+//     region: '',
+//     playerPeriod: '',
+//     playerNumber: '',
+//     playerOld: '',
+//     playerPosition: '',
+//     playerAthlete: false,
+//     contents: ''
+//   });
+
+//   const [errors, setErrors] = useState({});
+
+//   useEffect(() => {
+//     const token = localStorage.getItem("token");
+//     axios.get(`http://localhost:8080/api/enroll/${playerIdx}`, {
+//       headers: { 'Authorization' : token }
+//     })
+//       .then(response => {
+//         setFormData(response.data);
+//       })
+//       .catch(error => {
+//         console.error('Error fetching player details:', error);
+//       });
+//   }, [playerIdx]);
+
+//   const validate = () => {
+//     const newErrors = {};
+
+//     if (!formData.title.trim()) {
+//       newErrors.title = '제목을 입력해주세요.';
+//     }
+
+//     setErrors(newErrors);
+//     return Object.keys(newErrors).length === 0;
+//   };
+
+//   const handleChange = (e) => {
+//     const { name, value, type, checked } = e.target;
+//     setFormData({
+//       ...formData,
+//       [name]: type === 'checkbox' ? checked : value
+//     });
+//   };
+
+//   const handleSubmit = async (e) => {
+//     e.preventDefault();
+
+//     if (!validate()) {
+//       return;
+//     }
+
+//     try {
+//       const token = localStorage.getItem("token");
+//       await axios.put(`http://localhost:8080/api/soccerTeam/player/${playerIdx}/edit?teamIdx=${formData.teamIdx}`, formData, {
+//         headers: { Authorization: 'Bearer ' + token }
+//       });
+//       navigate(`/playerDetail/${playerIdx}`);
+//     } catch (error) {
+//       console.error('Error updating player:', error);
+//     }
+//   };
+
+//   return (
+//     <div className="container">
+//       <h2>선수 정보 수정</h2>
+//       <form onSubmit={handleSubmit}>
+//         <table className="player_write">
+//           <tbody>
+//             <tr>
+//               <td>제목</td>
+//               <td><input type="text" name="title" value={formData.title} onChange={handleChange} /></td>
+//             </tr>
+//             {errors.title && <p className="error">{errors.title}</p>}
+//             <tr>
+//               <td>본인 이름</td>
+//               <td><input type="text" name="playerName" value={formData.playerName} onChange={handleChange} /></td>
+//             </tr>
+//             {errors.playerName && <p className="error">{errors.playerName}</p>}
+//             <tr>
+//               <td>거주 지역</td>
+//               <td><input type="text" name="region" value={formData.region} onChange={handleChange} /></td>
+//             </tr>
+//             {errors.region && <p className="error">{errors.region}</p>}
+//             <tr>
+//               <td>구력</td>
+//               <td><input type="number" name="playerPeriod" value={formData.playerPeriod} onChange={handleChange} /></td>
+//             </tr>
+//             <tr>
+//               <td>연락처</td>
+//               <td><input type="text" name="playerNumber" value={formData.playerNumber} onChange={handleChange} /></td>
+//             </tr>
+//             {errors.playerNumber && <p className="error">{errors.playerNumber}</p>}
+//             <tr>
+//               <td>나이</td>
+//               <td><input type="number" name="playerOld" value={formData.playerOld} onChange={handleChange} /></td>
+//             </tr>
+//             {errors.playerOld && <p className="error">{errors.playerOld}</p>}
+//             <tr>
+//               <td>포지션</td>
+//               <td><input type="text" name="playerPosition" value={formData.playerPosition} onChange={handleChange} /></td>
+//             </tr>
+//             {errors.playerPosition && <p className="error">{errors.playerPosition}</p>}
+//             <tr>
+//               <td>선출 여부</td>
+//               <td><input type="checkbox" name="playerAthlete" checked={formData.playerAthlete} onChange={handleChange} /></td>
+//             </tr>
+//             <tr>
+//               <td>자기소개</td>
+//               <td><textarea name="contents" value={formData.contents} onChange={handleChange}></textarea></td>
+//             </tr>
+//           </tbody>
+//         </table>
+//         <div className="btnP-container">
+//           <input type="submit" value="저장" className="btnP" />
+//           <button type="button" className="btnP" onClick={() => navigate(`/playerDetail/${playerIdx}`)}>취소</button>
+//         </div>
+//       </form>
+//     </div>
+//   );
+// }
+
+// export default PlayerModify;
+
 import React, { useState, useEffect } from 'react';
 import axios from 'axios';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, useLocation } from 'react-router-dom';
+import '../css/CommonStyle.css';
 import '../css/PlayerWrite.css';
 
 function PlayerModify() {
@@ -15,45 +149,21 @@ function PlayerModify() {
     playerOld: '',
     playerPosition: '',
     playerAthlete: false,
-    contents: '',
-    teamIdx: ''
+    contents: ''
   });
-
+  const location = useLocation();
   const [errors, setErrors] = useState({});
 
   useEffect(() => {
-    const token = localStorage.getItem("token");
-    axios.get(`http://localhost:8080/api/soccerTeam/player/${playerIdx}`, {
-      headers: { Authorization: 'Bearer ' + token }
-    })
-      .then(response => {
-        setFormData(response.data);
-      })
-      .catch(error => {
-        console.error('Error fetching player details:', error);
-      });
-  }, [playerIdx]);
+    console.log(location.state.player);
+    setFormData(location.state.player);
+  }, [location.state.player]);
 
   const validate = () => {
     const newErrors = {};
 
     if (!formData.title.trim()) {
       newErrors.title = '제목을 입력해주세요.';
-    }
-    if (!formData.playerName.trim()) {
-      newErrors.playerName = '이름을 입력해주세요.';
-    }
-    if (!formData.region.trim()) {
-      newErrors.region = '거주 지역을 입력해주세요.';
-    }
-    if (!formData.playerNumber || !/^\d{3}-\d{4}-\d{4}$/.test(formData.playerNumber)) {
-      newErrors.playerNumber = '전화번호는 000-0000-0000 형식이어야 합니다.';
-    }
-    if (!formData.playerOld || formData.playerOld < 10 || formData.playerOld > 100) {
-      newErrors.playerOld = '유효한 나이를 입력해주세요.';
-    }
-    if (!formData.playerPosition.trim()) {
-      newErrors.playerPosition = '포지션을 입력해주세요.';
     }
 
     setErrors(newErrors);
@@ -77,14 +187,16 @@ function PlayerModify() {
 
     try {
       const token = localStorage.getItem("token");
-      await axios.put(`http://localhost:8080/api/soccerTeam/player/${playerIdx}/edit?teamIdx=${formData.teamIdx}`, formData, {
-        headers: { Authorization: 'Bearer ' + token }
+      await axios.put(`http://localhost:8080/api/enroll/${playerIdx}`, formData, {
+        headers: { Authorization: token }
       });
       navigate(`/playerDetail/${playerIdx}`);
     } catch (error) {
       console.error('Error updating player:', error);
     }
   };
+
+  if (!formData) return <div>Loading...</div>;
 
   return (
     <div className="container">
@@ -94,17 +206,17 @@ function PlayerModify() {
           <tbody>
             <tr>
               <td>제목</td>
-              <td><input type="text" name="title" value={formData.title} onChange={handleChange} /></td>
+              <td><input type="text" name="title" value={formData.title} onChange={handleChange} required /></td>
             </tr>
             {errors.title && <p className="error">{errors.title}</p>}
             <tr>
               <td>본인 이름</td>
-              <td><input type="text" name="playerName" value={formData.playerName} onChange={handleChange} /></td>
+              <td><input type="text" name="playerName" value={formData.playerName} onChange={handleChange} required /></td>
             </tr>
             {errors.playerName && <p className="error">{errors.playerName}</p>}
             <tr>
               <td>거주 지역</td>
-              <td><input type="text" name="region" value={formData.region} onChange={handleChange} /></td>
+              <td><input type="text" name="region" value={formData.region} onChange={handleChange} required /></td>
             </tr>
             {errors.region && <p className="error">{errors.region}</p>}
             <tr>
@@ -113,17 +225,17 @@ function PlayerModify() {
             </tr>
             <tr>
               <td>연락처</td>
-              <td><input type="text" name="playerNumber" value={formData.playerNumber} onChange={handleChange} /></td>
+              <td><input type="text" name="playerNumber" value={formData.playerNumber} onChange={handleChange} required /></td>
             </tr>
             {errors.playerNumber && <p className="error">{errors.playerNumber}</p>}
             <tr>
               <td>나이</td>
-              <td><input type="number" name="playerOld" value={formData.playerOld} onChange={handleChange} /></td>
+              <td><input type="number" name="playerOld" value={formData.playerOld} onChange={handleChange} required /></td>
             </tr>
             {errors.playerOld && <p className="error">{errors.playerOld}</p>}
             <tr>
               <td>포지션</td>
-              <td><input type="text" name="playerPosition" value={formData.playerPosition} onChange={handleChange} /></td>
+              <td><input type="text" name="playerPosition" value={formData.playerPosition} onChange={handleChange} required /></td>
             </tr>
             {errors.playerPosition && <p className="error">{errors.playerPosition}</p>}
             <tr>

--- a/src/soccerTeam/PlayerModify.js
+++ b/src/soccerTeam/PlayerModify.js
@@ -1,136 +1,3 @@
-// import React, { useState, useEffect } from 'react';
-// import axios from 'axios';
-// import { useParams, useNavigate } from 'react-router-dom';
-// import '../css/PlayerWrite.css';
-
-// function PlayerModify() {
-//   const { playerIdx } = useParams();
-//   const navigate = useNavigate();
-//   const [formData, setFormData] = useState({
-//     title: '',
-//     playerName: '',
-//     region: '',
-//     playerPeriod: '',
-//     playerNumber: '',
-//     playerOld: '',
-//     playerPosition: '',
-//     playerAthlete: false,
-//     contents: ''
-//   });
-
-//   const [errors, setErrors] = useState({});
-
-//   useEffect(() => {
-//     const token = localStorage.getItem("token");
-//     axios.get(`http://localhost:8080/api/enroll/${playerIdx}`, {
-//       headers: { 'Authorization' : token }
-//     })
-//       .then(response => {
-//         setFormData(response.data);
-//       })
-//       .catch(error => {
-//         console.error('Error fetching player details:', error);
-//       });
-//   }, [playerIdx]);
-
-//   const validate = () => {
-//     const newErrors = {};
-
-//     if (!formData.title.trim()) {
-//       newErrors.title = '제목을 입력해주세요.';
-//     }
-
-//     setErrors(newErrors);
-//     return Object.keys(newErrors).length === 0;
-//   };
-
-//   const handleChange = (e) => {
-//     const { name, value, type, checked } = e.target;
-//     setFormData({
-//       ...formData,
-//       [name]: type === 'checkbox' ? checked : value
-//     });
-//   };
-
-//   const handleSubmit = async (e) => {
-//     e.preventDefault();
-
-//     if (!validate()) {
-//       return;
-//     }
-
-//     try {
-//       const token = localStorage.getItem("token");
-//       await axios.put(`http://localhost:8080/api/soccerTeam/player/${playerIdx}/edit?teamIdx=${formData.teamIdx}`, formData, {
-//         headers: { Authorization: 'Bearer ' + token }
-//       });
-//       navigate(`/playerDetail/${playerIdx}`);
-//     } catch (error) {
-//       console.error('Error updating player:', error);
-//     }
-//   };
-
-//   return (
-//     <div className="container">
-//       <h2>선수 정보 수정</h2>
-//       <form onSubmit={handleSubmit}>
-//         <table className="player_write">
-//           <tbody>
-//             <tr>
-//               <td>제목</td>
-//               <td><input type="text" name="title" value={formData.title} onChange={handleChange} /></td>
-//             </tr>
-//             {errors.title && <p className="error">{errors.title}</p>}
-//             <tr>
-//               <td>본인 이름</td>
-//               <td><input type="text" name="playerName" value={formData.playerName} onChange={handleChange} /></td>
-//             </tr>
-//             {errors.playerName && <p className="error">{errors.playerName}</p>}
-//             <tr>
-//               <td>거주 지역</td>
-//               <td><input type="text" name="region" value={formData.region} onChange={handleChange} /></td>
-//             </tr>
-//             {errors.region && <p className="error">{errors.region}</p>}
-//             <tr>
-//               <td>구력</td>
-//               <td><input type="number" name="playerPeriod" value={formData.playerPeriod} onChange={handleChange} /></td>
-//             </tr>
-//             <tr>
-//               <td>연락처</td>
-//               <td><input type="text" name="playerNumber" value={formData.playerNumber} onChange={handleChange} /></td>
-//             </tr>
-//             {errors.playerNumber && <p className="error">{errors.playerNumber}</p>}
-//             <tr>
-//               <td>나이</td>
-//               <td><input type="number" name="playerOld" value={formData.playerOld} onChange={handleChange} /></td>
-//             </tr>
-//             {errors.playerOld && <p className="error">{errors.playerOld}</p>}
-//             <tr>
-//               <td>포지션</td>
-//               <td><input type="text" name="playerPosition" value={formData.playerPosition} onChange={handleChange} /></td>
-//             </tr>
-//             {errors.playerPosition && <p className="error">{errors.playerPosition}</p>}
-//             <tr>
-//               <td>선출 여부</td>
-//               <td><input type="checkbox" name="playerAthlete" checked={formData.playerAthlete} onChange={handleChange} /></td>
-//             </tr>
-//             <tr>
-//               <td>자기소개</td>
-//               <td><textarea name="contents" value={formData.contents} onChange={handleChange}></textarea></td>
-//             </tr>
-//           </tbody>
-//         </table>
-//         <div className="btnP-container">
-//           <input type="submit" value="저장" className="btnP" />
-//           <button type="button" className="btnP" onClick={() => navigate(`/playerDetail/${playerIdx}`)}>취소</button>
-//         </div>
-//       </form>
-//     </div>
-//   );
-// }
-
-// export default PlayerModify;
-
 import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
@@ -140,30 +7,39 @@ import '../css/PlayerWrite.css';
 function PlayerModify() {
   const { playerIdx } = useParams();
   const navigate = useNavigate();
-  const [formData, setFormData] = useState({
-    title: '',
-    playerName: '',
-    region: '',
-    playerPeriod: '',
-    playerNumber: '',
-    playerOld: '',
-    playerPosition: '',
-    playerAthlete: false,
-    contents: ''
-  });
   const location = useLocation();
+  const { teamId } = location.state || {};
+  const [formData, setFormData] = useState({
+    id: '',
+    title: '',
+    content: '',
+    position: ''
+  });
+  
   const [errors, setErrors] = useState({});
 
   useEffect(() => {
-    console.log(location.state.player);
-    setFormData(location.state.player);
-  }, [location.state.player]);
+    if (location.state && location.state.enroll) {
+      setFormData({
+        id: location.state.enroll.id,
+        title: location.state.enroll.title,
+        content: location.state.enroll.content,
+        position: location.state.enroll.position
+      });
+    }
+  }, [location.state]);
 
   const validate = () => {
     const newErrors = {};
 
     if (!formData.title.trim()) {
       newErrors.title = '제목을 입력해주세요.';
+    }
+    if (!formData.content.trim()) {
+      newErrors.content = '자기소개를 입력해주세요.';
+    }
+    if (!formData.position.trim()) {
+      newErrors.position = '선호 포지션을 입력해주세요.';
     }
 
     setErrors(newErrors);
@@ -187,12 +63,22 @@ function PlayerModify() {
 
     try {
       const token = localStorage.getItem("token");
-      await axios.put(`http://localhost:8080/api/enroll/${playerIdx}`, formData, {
-        headers: { Authorization: token }
+      await axios.put(`http://localhost:8080/api/enroll`, formData, {
+        headers: { 'Authorization': token }
       });
-      navigate(`/playerDetail/${playerIdx}`);
+      navigate(`/playerDetail/${playerIdx}`, { state: { teamId } });
     } catch (error) {
-      console.error('Error updating player:', error);
+      if (error.response) {
+        const errorMessage = error.response.data.message;
+        if (errorMessage === 'ONLY_OWNER_CAN_MODIFY') {
+          alert('본인의 입단 신청서만 수정 가능합니다');
+        } else {
+          alert(errorMessage || '알 수 없는 오류가 발생했습니다.');
+        }
+      } else {
+        console.error('Error updating player:', error);
+        alert('서버에 연결할 수 없습니다. 나중에 다시 시도해 주세요.');
+      }
     }
   };
 
@@ -210,47 +96,19 @@ function PlayerModify() {
             </tr>
             {errors.title && <p className="error">{errors.title}</p>}
             <tr>
-              <td>본인 이름</td>
-              <td><input type="text" name="playerName" value={formData.playerName} onChange={handleChange} required /></td>
-            </tr>
-            {errors.playerName && <p className="error">{errors.playerName}</p>}
-            <tr>
-              <td>거주 지역</td>
-              <td><input type="text" name="region" value={formData.region} onChange={handleChange} required /></td>
-            </tr>
-            {errors.region && <p className="error">{errors.region}</p>}
-            <tr>
-              <td>구력</td>
-              <td><input type="number" name="playerPeriod" value={formData.playerPeriod} onChange={handleChange} /></td>
-            </tr>
-            <tr>
-              <td>연락처</td>
-              <td><input type="text" name="playerNumber" value={formData.playerNumber} onChange={handleChange} required /></td>
-            </tr>
-            {errors.playerNumber && <p className="error">{errors.playerNumber}</p>}
-            <tr>
-              <td>나이</td>
-              <td><input type="number" name="playerOld" value={formData.playerOld} onChange={handleChange} required /></td>
-            </tr>
-            {errors.playerOld && <p className="error">{errors.playerOld}</p>}
-            <tr>
-              <td>포지션</td>
-              <td><input type="text" name="playerPosition" value={formData.playerPosition} onChange={handleChange} required /></td>
-            </tr>
-            {errors.playerPosition && <p className="error">{errors.playerPosition}</p>}
-            <tr>
-              <td>선출 여부</td>
-              <td><input type="checkbox" name="playerAthlete" checked={formData.playerAthlete} onChange={handleChange} /></td>
-            </tr>
-            <tr>
               <td>자기소개</td>
-              <td><textarea name="contents" value={formData.contents} onChange={handleChange}></textarea></td>
+              <td><textarea name="content" value={formData.content} onChange={handleChange} required></textarea></td>
             </tr>
+            {errors.content && <p className="error">{errors.content}</p>}
+            <tr>
+              <td>선호 포지션</td>
+              <td colSpan="2"><textarea name="position" value={formData.position} onChange={handleChange} required></textarea></td>
+            </tr> 
           </tbody>
         </table>
         <div className="btnP-container">
           <input type="submit" value="저장" className="btnP" />
-          <button type="button" className="btnP" onClick={() => navigate(`/playerDetail/${playerIdx}`)}>취소</button>
+          <button type="button" className="btnP" onClick={() => navigate(`/playerDetail/${playerIdx}`, { state: { teamId } })}>취소</button>
         </div>
       </form>
     </div>

--- a/src/soccerTeam/PlayerModify.js
+++ b/src/soccerTeam/PlayerModify.js
@@ -70,11 +70,7 @@ function PlayerModify() {
     } catch (error) {
       if (error.response) {
         const errorMessage = error.response.data.message;
-        if (errorMessage === 'ONLY_OWNER_CAN_MODIFY') {
-          alert('본인의 입단 신청서만 수정 가능합니다');
-        } else {
-          alert(errorMessage || '알 수 없는 오류가 발생했습니다.');
-        }
+        alert(errorMessage || '알 수 없는 오류가 발생했습니다.');
       } else {
         console.error('Error updating player:', error);
         alert('서버에 연결할 수 없습니다. 나중에 다시 시도해 주세요.');

--- a/src/soccerTeam/PlayerModify.js
+++ b/src/soccerTeam/PlayerModify.js
@@ -20,12 +20,7 @@ function PlayerModify() {
 
   useEffect(() => {
     if (location.state && location.state.enroll) {
-      setFormData({
-        id: location.state.enroll.id,
-        title: location.state.enroll.title,
-        content: location.state.enroll.content,
-        position: location.state.enroll.position
-      });
+      setFormData(location.state.enroll);
     }
   }, [location.state]);
 
@@ -61,9 +56,16 @@ function PlayerModify() {
       return;
     }
 
+    const trimmedData = {
+      ...formData,
+      title: formData.title.trim(),
+      content: formData.content.trim(),
+      position: formData.position.trim()
+  };
+
     try {
       const token = localStorage.getItem("token");
-      await axios.put(`http://localhost:8080/api/enroll`, formData, {
+      await axios.put(`http://localhost:8080/api/enroll`, trimmedData, {
         headers: { 'Authorization': token }
       });
       navigate(`/playerDetail/${playerIdx}`, { state: { teamId } });

--- a/src/soccerTeam/PlayerWrite.js
+++ b/src/soccerTeam/PlayerWrite.js
@@ -18,6 +18,9 @@ function PlayerWrite() {
     if (!formData.title.trim()) {
       newErrors.title = '제목을 입력해주세요.';
     }
+    if (!formData.contents.trim()) {
+      newErrors.contents = '자기소개를 입력해주세요.';
+    }
 
     setErrors(newErrors);
     return Object.keys(newErrors).length === 0;
@@ -44,7 +47,7 @@ function PlayerWrite() {
         ...formData,
         teamId: teamIdx,
         title: formData.title,
-        content: formData.contents
+        contents: formData.contents
       }, {
         headers: {
           'Authorization': token
@@ -71,6 +74,7 @@ function PlayerWrite() {
               <td>자기소개</td>
               <td colSpan="2"><textarea name="contents" value={formData.contents} onChange={handleChange} required></textarea></td>
             </tr>
+            {errors.contents && <p className="error">{errors.contents}</p>}
           </tbody>
         </table>
         <div className="btnP-container">

--- a/src/soccerTeam/PlayerWrite.js
+++ b/src/soccerTeam/PlayerWrite.js
@@ -7,7 +7,7 @@ function PlayerWrite() {
   const { teamIdx } = useParams(); 
   const [formData, setFormData] = useState({
     title: '',
-    contents: '',
+    content: '',
     position: '',
   });
   const navigate = useNavigate();
@@ -19,8 +19,8 @@ function PlayerWrite() {
     if (!formData.title.trim()) {
       newErrors.title = '제목을 입력해주세요.';
     }
-    if (!formData.contents.trim()) {
-      newErrors.contents = '자기소개를 입력해주세요.';
+    if (!formData.content.trim()) {
+      newErrors.content = '자기소개를 입력해주세요.';
     }
 
     setErrors(newErrors);
@@ -48,7 +48,7 @@ function PlayerWrite() {
         ...formData,
         teamId: teamIdx,
         title: formData.title,
-        contents: formData.contents
+        content: formData.content
       }, {
         headers: {
           'Authorization': token
@@ -73,9 +73,9 @@ function PlayerWrite() {
             {errors.title && <p className="error">{errors.title}</p>}
             <tr>
               <td>자기소개</td>
-              <td colSpan="2"><textarea name="contents" value={formData.contents} onChange={handleChange} required></textarea></td>
+              <td colSpan="2"><textarea name="content" value={formData.content} onChange={handleChange} required></textarea></td>
             </tr>
-            {errors.contents && <p className="error">{errors.contents}</p>}
+            {errors.content && <p className="error">{errors.content}</p>}
             <tr>
               <td>선호 포지션</td>
               <td colSpan="2"><textarea name="position" value={formData.position} onChange={handleChange} required></textarea></td>


### PR DESCRIPTION
1. 백엔드에서는 update에 teamId가 필요없지만, 프론트에서 PlayerModify.js에서 저장이나 취소버튼을 눌러 PlayerDetail.js로 이동할 때 teamId가 필요하여 유지시켰습니다.
2. PlayerDetail에서 teamId를 보내주지 않아 undefined 뜨던 것을 수정했습니다.
3. useEffect에서 수정하려는 선수의 기존 데이터를 폼에 미리 채워넣기 초기화를 진행하고, location.state에 데이터가 존재하지 않는 경우를 위해 if문을 사용하여 enroll 객체가 존재하는지 확인합니다.
4. handleChange 함수에서 사용자가 입력한 값을 formData에 업데이트합니다.
5. handleSubmit 함수가 폼 제출 시 호출되어 데이터가 유효한 경우 서버로 PUT 요청을 보냅니다.
6. 다른 사용자의 입단 신청서를 수정할 때 alert로 오류 메시지를 출력하도록 했습니다.

<img width="1555" alt="image" src="https://github.com/user-attachments/assets/a66150ab-2e0f-4880-9a52-aa9e6b332143">

<img width="1555" alt="image" src="https://github.com/user-attachments/assets/c7c27390-2804-4d22-a513-5a0da3891298">

<img width="1555" alt="image" src="https://github.com/user-attachments/assets/6b4d03c6-d45d-4f73-8908-ce727d780e24">

<img width="1555" alt="image" src="https://github.com/user-attachments/assets/7f008adc-9e69-4026-9f35-3292cd36bf97">

<img width="1555" alt="image" src="https://github.com/user-attachments/assets/e5c7db3a-9bad-434f-8989-3bb72fc23a42">

------------------------------------------

- setFormData(location.state.enroll)로 해도 정상 동작하여 변경하였습니다.
- 기타 수정 사항을 반영했습니다.
- validation check에서 trim을 사용했기 때문에 수정을 완료하여 fromData를 전송할 때도 trim을 써서 공백을 지워 데이터의 일관성이 유지했습니다.