### PR TITLE
fix: 입단신청서 소유자 확인

### DIFF
--- a/src/soccerTeam/PlayerDetail.js
+++ b/src/soccerTeam/PlayerDetail.js
@@ -10,14 +10,17 @@ function PlayerDetail() {
   const location = useLocation();
   const { teamId } = location.state || {};
   const [enroll, setEnroll] = useState(null);
+  const [isOwner, setIsOwner] = useState(false);  // 작성자 여부 상태 추가
 
   useEffect(() => {
     const token = localStorage.getItem("token");
     axios.get(`http://localhost:8080/api/enroll/${playerIdx}`, {
-      headers: { Authorization: token }
+      headers: { 'Authorization': token }
     })
       .then(response => {
-        setEnroll(response.data.data);
+        const enrollData = response.data.data;
+        setEnroll(enrollData);
+        setIsOwner(enrollData.isOwner);  // 작성자인지 여부를 상태에 저장
       })
       .catch(error => {
         console.error('Error fetching player details:', error);
@@ -103,8 +106,12 @@ function PlayerDetail() {
         </table>
       </form>
       <button className="btnPD" onClick={() => navigate(`/soccerTeam/${teamId}`)}>목록으로</button>
-      <button className="btnPD" onClick={() => {navigate(`/playerModify/${playerIdx}`, { state: { enroll, teamId } });}}>수정하기</button>
-      <button className="btnPD" onClick={handleDelete}>삭제하기</button>
+      {isOwner && (  // 작성자만 수정하기와 삭제하기 버튼이 보이게 함
+        <>
+          <button className="btnPD" onClick={() => navigate(`/playerModify/${playerIdx}`, { state: { enroll, teamId } })}>수정하기</button>
+          <button className="btnPD" onClick={handleDelete}>삭제하기</button>
+        </>
+      )}
     </div>
   );
 }

--- a/src/soccerTeam/PlayerWrite.js
+++ b/src/soccerTeam/PlayerWrite.js
@@ -79,7 +79,7 @@ function PlayerWrite() {
             <tr>
               <td>선호 포지션</td>
               <td colSpan="2"><textarea name="position" value={formData.position} onChange={handleChange} required></textarea></td>
-            </tr> 
+            </tr>
           </tbody>
         </table>
         <div className="btnP-container">


### PR DESCRIPTION
**로컬 브랜치에서 pull과 커밋 순서를 잘못하여 이전 커밋도 포함되어버렸습니다. 'fix: 입단신청서 소유자 확인' 커밋 확인하시면 됩니다!**

사용자가 작성한 게시글에 접근할 때, 토큰을 이용하여 작성자와 현재 접속한 사용자가 일치하는 경우에만 '수정하기'와 '삭제하기' 버튼이 나타나도록 구현했습니다.

- useEffect가 동작할 때 로컬 스토리지에 저장된 JWT 토큰을 함께 전송하여 백엔드에서 인증을 진행하도록 합니다.
- 백엔드에서 받은 응답에 포함된 isOwner 값을 통해 현재 사용자가 작성자인지 확인하고, isOwner 상태가 true일 때 수정하기와 삭제하기 버튼이 화면에 나타납니다.
- handleDelete 함수는 사용자가 삭제 버튼을 클릭할 때 호출되며, JWT 토큰을 포함한 DELETE 요청을 백엔드로 보냅니다.

-'테스터' 사용자가 로그인했을 때-
<img width="1029" alt="image" src="https://github.com/user-attachments/assets/cae569c3-fa72-4309-94ba-7c4ca9426a9a">

<img width="1029" alt="image" src="https://github.com/user-attachments/assets/a606dd04-2650-4c0b-83c3-8983557fcd36">